### PR TITLE
lenient linx

### DIFF
--- a/src/main/scala/linx/Linx.scala
+++ b/src/main/scala/linx/Linx.scala
@@ -21,10 +21,7 @@ object Linx {
 }
 
 sealed trait Linx[A, X] {
-  def split(s:String) = s.split('/').toList match {
-    case "" :: t => t
-    case t       => t
-  }
+  def split(s: String) = s.split("/").filterNot(_.isEmpty).toList
 
   def links(a:A) = elements(a).map(_.mkString("/", "/", ""))
 
@@ -60,7 +57,7 @@ sealed trait Linx[A, X] {
 class StaticLinx(val static:Vector[String]) extends Linx[Unit, Boolean]{
   def unapply(s:String) = extract(split(s)).exists(_._2.isEmpty)
 
-  def /(name: String) = new StaticLinx(static :+ name)
+  def /(name: String) = new StaticLinx(static ++ split(name))
 
   def elements(a: Unit) = Stream(static)
 
@@ -71,7 +68,7 @@ class StaticLinx(val static:Vector[String]) extends Linx[Unit, Boolean]{
 }
 
 class VariableLinx[P, A](parent:Linx[P, _], param:LinxParam[P, A], static:Vector[String], symbol:Symbol) extends Linx[A, Option[A]]{
-  def /(name: String) = new VariableLinx(parent, param, static :+ name, symbol)
+  def /(name: String) = new VariableLinx(parent, param, static ++ split(name), symbol)
 
   def elements(a: A) = {
     val (p, part) = param.previous(a)

--- a/src/test/scala/linx/LinxTest.scala
+++ b/src/test/scala/linx/LinxTest.scala
@@ -154,4 +154,34 @@ class LinxTest {
     def rails(s:String) = ":"+s
     assertEquals(X.template(rails), "/a/:a/x/:x")
   }
+
+  @Test
+  def lenientLiteral() = {
+    val X    = Root / "/A" / "B/C"
+    val path = "/A/B/C"
+    val X()  = path
+
+    assertEquals(path, X())
+  }
+
+  @Test
+  def lenientVariable() = {
+    val X    = Root / 'x / "//bar/baz///"
+    val path = "/foo/bar/baz"
+    val X(x) = path
+
+    assertEquals("foo", x)
+    assertEquals(X(x), path)
+  }
+
+  @Test
+  def lenientUnapply() = {
+    val X    = Root / 'x / "//bar/baz///"
+    val path = "/foo/bar/baz"
+    val X(x) = path.replaceAll("/", "//")
+
+    assertEquals("foo", x)
+    assertEquals(X(x), path)
+  }
+
 }


### PR DESCRIPTION
I know this probably wasn't the intention when you wrote it, but it has been very practical to wire up things like say Root / servletContext.getContextPath / "foo" / stringFromElsewhere without manually accounting for slashes. What do you think?
